### PR TITLE
add better example for array comprehension

### DIFF
--- a/array-comprehension.js
+++ b/array-comprehension.js
@@ -1,3 +1,10 @@
-[ for (value of ["Harriet", "178"]) value ].join(" was ");
-// Would give us "Harriet was 178"
-// BTW it was Charles Darwin's tortoise.
+var numbers = [ 1, 4, 9 ];
+[for (num of numbers) Math.sqrt(num)];
+// => [ 1, 2, 3 ]
+
+[for (x of [ 1, 2, 3]) for (y of [ 3, 2, 1 ]) x*y];
+// => [ 3, 2, 1, 6, 4, 2, 9, 6, 3 ]
+
+[for (x of [ 1, 2, 3, 4, 5, 6 ]) if (x%2 === 0) x];
+// => [ 2, 4, 6 ]
+


### PR DESCRIPTION
The current example could also be done like this.
```js
["Harriet", "178"].join(" was ");
```
There is no need for an array-comprehension there.