### PR TITLE
Fix lack of return in direct-proxy

### DIFF
--- a/direct-proxy.js
+++ b/direct-proxy.js
@@ -5,7 +5,7 @@ let NegativeIndices = (array) => {
       console.log('Proxy#get', array, name);
       index = parseInt(name);
       if (!isNaN(index) && index < 0) {
-        array[array.length + index];
+        return array[array.length + index];
       } else {
         return array[name];
       }


### PR DESCRIPTION
Instead of the desired effect, it would return `undefined` on negative array indices.

Tested with `iojs --harmony_proxies --harmony_arrow_functions -r harmony-reflect direct-proxy.js`