### PR TITLE
Make map argument string literal

### DIFF
--- a/maps.js
+++ b/maps.js
@@ -5,5 +5,5 @@ m.has('answer');                //  true
 m.delete('answer');               //  true
 m.has('answer');                  //  false
 
-m.set(keyFunc,() => "foo");
-m.get(keyFunc)(); // "foo"
+m.set('keyFunc',() => "foo");
+m.get('keyFunc')(); // "foo"


### PR DESCRIPTION
Otherwise `keyFunc is not defined` - as in this [babel demo](https://babeljs.io/repl/#?experimental=false&evaluate=true&loose=false&spec=false&code=let%20m%20%3D%20new%20Map()%3B%0Am.set('answer'%2C%2042)%3B%0Am.get('answer')%3B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%2042%0Am.has('answer')%3B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%20true%0Am.delete('answer')%3B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%20true%0Am.has('answer')%3B%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2F%2F%20%20false%0A%0Am.set(keyFunc%2C()%20%3D%3E%20%22foo%22)%3B%0Am.get(keyFunc)()%3B%20%2F%2F%20%22foo%22).