### PR TITLE
better example for WeakMap

### DIFF
--- a/weakmaps.js
+++ b/weakmaps.js
@@ -12,6 +12,6 @@ wm.get(wmk); // "life"
 
 wm.has(wmk); // true
 
-wm.delete(wmk); // true
+wmk = undefined;
 
 wm.has(wmk); //false

--- a/weakmaps.js
+++ b/weakmaps.js
@@ -6,12 +6,20 @@ wm.set('life', 'life'.length) //TypeError: Invalid value used as weak map key
 
 var wmk = {};
 
-wm.set(wmk,'life');
+wm.set(wmk, 'life');
 
 wm.get(wmk); // "life"
 
 wm.has(wmk); // true
 
-wmk = undefined;
+wm.delete(wmk); // true
 
 wm.has(wmk); //false
+
+var key = {}
+
+wm.set(key, 'value');
+
+key = undefined; // key disappeared
+
+wm.has(key); // false; entry disappeared automatically


### PR DESCRIPTION
Previous example doesn't show the feature of WeakMap since we delete the key explicitly.  Same goes for WeakSet

> The key in a WeakMap is held weakly.  What this means is that, if there are no other strong references to the key, then the entire entry will be removed from the WeakMap by the garbage collector.

Another example will be a page element as key, later the page element is removed from the page?

wm.set($('#banner'), 'banner exist');

$('#banner').remove();

wm.has($('#banner')); // false

I wonder why the MDN page doesn't have a example like this.  I think the point of WeakMap is you don't need to delete the entries.  The garbage collector does it for you.